### PR TITLE
remove dependency on Plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,11 @@ version = "0.0.1"
 
 [deps]
 EcologicalNetworks = "26cd3c7c-942f-11e8-1e85-357945f36438"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Plots"]

--- a/src/EcologicalNetworksPlots.jl
+++ b/src/EcologicalNetworksPlots.jl
@@ -1,7 +1,6 @@
 module EcologicalNetworksPlots
 
 using EcologicalNetworks
-using Plots
 using RecipesBase
 
 # Various layout manipulation functions


### PR DESCRIPTION
This removes Plots as a dependency but retains it as a testing dependency.
As far as I can see there is no use of Plots functionality in this package not already in RecipesBase (I couldn't test it as tests are failing, at least on julia-1.1).

This PR makes this package essentally dependency-free: RecipesBase is 400 loca with no dependencies itself, no exported names, and updates like a stdlib - only together with new Julia minor versions. The purpose of RecipesBase is to obviate the need for glue packages like this one, which could be merged into EcologicalNetworks at no cost (it will not collide with possible glue packages created for other plotting packages).